### PR TITLE
Add failing test for EntityQueryFilter equality.

### DIFF
--- a/src/Wallee.Test/EntityQueryFilterTests.cs
+++ b/src/Wallee.Test/EntityQueryFilterTests.cs
@@ -1,0 +1,39 @@
+namespace Wallee.Test
+{
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using Wallee.Model;
+
+    [TestFixture]
+    public sealed class EntityQueryFilterTests
+    {
+        [Test]
+        public void EqualityWithoutChildrenTest()
+        {
+            var leafFilter1 = new EntityQueryFilter(EntityQueryFilterType.LEAF)
+            {
+                FieldName = "field",
+                Operator = CriteriaOperator.EQUALS,
+                Value = "value"
+            };
+
+            var leafFilter2 = new EntityQueryFilter(EntityQueryFilterType.LEAF)
+            {
+                FieldName = "field2",
+                Operator = CriteriaOperator.EQUALS,
+                Value = "value2"
+            };
+
+            var andFilter = new EntityQueryFilter(EntityQueryFilterType.AND)
+            {
+                Children = new List<EntityQueryFilter>
+                {
+                    leafFilter1,
+                    leafFilter2
+                }
+            };
+
+            Assert.DoesNotThrow(() => andFilter.Equals(leafFilter1));
+        }
+    }
+}

--- a/src/Wallee/Model/EntityQueryFilter.cs
+++ b/src/Wallee/Model/EntityQueryFilter.cs
@@ -124,6 +124,7 @@ namespace Wallee.Model
                 (
                     this.Children == input.Children ||
                     this.Children != null &&
+                    input.Children != null &&
                     this.Children.SequenceEqual(input.Children)
                 ) && 
                 (


### PR DESCRIPTION
Hello there! I was trying to perform a query structured like the one in the test, when I found that the request would fail with the following exception:

```
Unhandled exception. Wallee.Client.ApiException: Value cannot be null. (Parameter 'second')
   at Wallee.Client.ApiClient.Serialize(Object obj)
   at Wallee.Service.ChargeAttemptService.SearchWithHttpInfo(Nullable`1 spaceId, EntityQuery query)
   at Wallee.Service.ChargeAttemptService.Search(Nullable`1 spaceId, EntityQuery query)
   at Program.main(String[] argv) in /home/auri/ConsoleApp2/Program.fs:line 40
```

After some investigation of the cryptic error message, I found out that the problem is in the equality between `EntityQueryFilters`. The issue is that `input.Children` may be null, and `IEnumerable.SequenceEqual` throws when either of the inputs is null. I added a test to reproduce the issue, and a fix for this specific type. I added an explicit check for `input.Children` being `null`. Alternatively, the problem could have been addressed by ensuring that the `Children` properties is always initialised with an empty list.

As a workaround for this issue, one can make sure to manually set each `Children` to an empty list, though _I imagine_ that is not the intended use of these filter objects.

:warning: Note that this issue **also affects all other objects** in the model that make use of `IEnumerable.SequenceEqual`. With a simple search for the method call I counted 132 usages.